### PR TITLE
feat: add ChatGPT Shell Tauri app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+*.log
+dist/
+src/**/*.js
+src/**/*.js.map
+src-tauri/target/
+**/.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# ChatGPTAppforLinux
+# ChatGPT Shell
+
+A small companion shell for launching the official ChatGPT site on Linux Mint (Ubuntu based) with handy local utilities.
+
+## Features
+- System tray with quick actions (open ChatGPT, quick prompt, screenshot, quit)
+- Global shortcuts
+- Snippet search and clipboard helpers
+- Screenshot capture to `~/Pictures/ChatGPT-Shots`
+- No webview or automation; opens your default browser in app mode
+
+## Dependencies
+Install prerequisite packages on Linux Mint/Ubuntu:
+```bash
+sudo apt update
+sudo apt install -y curl pkg-config libgtk-3-dev libayatana-appindicator3-dev \
+  libwebkit2gtk-4.1-dev build-essential scrot wmctrl xdotool
+```
+Install Rust and Node.js if not already:
+```bash
+curl https://sh.rustup.rs -sSf | sh
+sudo apt install -y nodejs npm
+```
+
+## Development
+```bash
+npm install
+npm run dev
+```
+
+## Build
+```bash
+npm run tauri build
+```
+
+See [privacy.md](src/privacy.md) for terms.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "chatgpt-shell",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tauri dev",
+    "build": "tsc",
+    "tauri": "tauri",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^1.5.0",
+    "fuse.js": "^6.6.2"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^1.5.9",
+    "typescript": "^5.4.0",
+    "eslint": "^8.56.0"
+  }
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "chatgpt-shell"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "1", features = ["system-tray", "global-shortcut", "clipboard-manager", "shell-open", "dialog-all", "notification-all", "window"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+which = "5"
+chrono = { version = "0.4", features = ["serde"] }
+thiserror = "1"
+dirs = "5"
+tauri-plugin-single-instance = "0.1"

--- a/src-tauri/icons/icon.svg
+++ b/src-tauri/icons/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="#10a37f"/>
+  <text x="50%" y="55%" font-size="220" text-anchor="middle" fill="#ffffff" font-family="sans-serif">GPT</text>
+</svg>

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+use std::sync::Mutex;
+use tauri::AppHandle;
+
+use crate::paths;
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Hotkeys {
+    pub open_chat: String,
+    pub quick_prompt: String,
+    pub screenshot: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Config {
+    pub chat_url: String,
+    pub hotkeys: Hotkeys,
+    pub browser_candidates: Vec<String>,
+}
+
+pub struct AppState {
+    pub config: Mutex<Config>,
+}
+
+impl AppState {
+    pub fn load(app: &AppHandle) -> Self {
+        let path = paths::config_path(app);
+        if !path.exists() {
+            if let Some(res) = app.path_resolver().resolve_resource("config.json") {
+                std::fs::create_dir_all(path.parent().unwrap()).ok();
+                let _ = std::fs::copy(res, &path);
+            }
+        }
+        let data = std::fs::read_to_string(&path).expect("config");
+        let config: Config = serde_json::from_str(&data).expect("parse config");
+        Self { config: Mutex::new(config) }
+    }
+}

--- a/src-tauri/src/browser.rs
+++ b/src-tauri/src/browser.rs
@@ -1,0 +1,23 @@
+use std::process::Command;
+use tauri::AppHandle;
+
+use crate::{app_state::Config, focus};
+
+pub fn open(app: &AppHandle, cfg: &Config) {
+    if focus::focus_existing().is_ok() {
+        return;
+    }
+    for b in &cfg.browser_candidates {
+        if which::which(b).is_ok() {
+            let _ = Command::new(b)
+                .args([format!("--app={}", cfg.chat_url), String::from("--new-window")])
+                .spawn();
+            return;
+        }
+    }
+    let _ = Command::new("xdg-open").arg(&cfg.chat_url).spawn();
+    let _ = tauri::api::notification::Notification::new(&app.config().tauri.bundle.identifier)
+        .title("ChatGPT Shell")
+        .body("No preferred browser found, used xdg-open")
+        .show();
+}

--- a/src-tauri/src/focus.rs
+++ b/src-tauri/src/focus.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+pub fn focus_existing() -> Result<(), ()> {
+    let try_wmctrl = Command::new("wmctrl").args(["-a", "ChatGPT"]).status();
+    if let Ok(s) = try_wmctrl {
+        if s.success() { return Ok(()); }
+    }
+    let try_xdotool = Command::new("xdotool").args(["search", "--name", "ChatGPT", "windowactivate"]).status();
+    if let Ok(s) = try_xdotool {
+        if s.success() { return Ok(()); }
+    }
+    Err(())
+}

--- a/src-tauri/src/global_hotkeys.rs
+++ b/src-tauri/src/global_hotkeys.rs
@@ -1,0 +1,30 @@
+use tauri::{AppHandle, Manager};
+
+use crate::{app_state::AppState, browser, screenshots};
+
+pub fn register(app: &AppHandle) {
+    let cfg = app.state::<AppState>().config.lock().unwrap().clone();
+    let open_app = app.clone();
+    if let Err(_) = app.global_shortcut_manager().register(cfg.hotkeys.open_chat.clone(), move || {
+        let cfg = open_app.state::<AppState>().config.lock().unwrap().clone();
+        browser::open(&open_app, &cfg);
+    }) {
+        tauri::api::dialog::message(Some(&app.get_window("main").unwrap()), "Failed to register open shortcut");
+    }
+    let prompt_app = app.clone();
+    if let Err(_) = app.global_shortcut_manager().register(cfg.hotkeys.quick_prompt.clone(), move || {
+        if let Some(w) = prompt_app.get_window("main") {
+            let vis = w.is_visible().unwrap_or(false);
+            if vis { let _ = w.hide(); } else { let _ = w.show(); let _ = w.set_focus(); }
+        }
+    }) {
+        tauri::api::dialog::message(Some(&app.get_window("main").unwrap()), "Failed to register prompt shortcut");
+    }
+    let shot_app = app.clone();
+    if let Err(_) = app.global_shortcut_manager().register(cfg.hotkeys.screenshot.clone(), move || {
+        let cfg = shot_app.state::<AppState>().config.lock().unwrap().clone();
+        screenshots::capture(&shot_app, &cfg);
+    }) {
+        tauri::api::dialog::message(Some(&app.get_window("main").unwrap()), "Failed to register screenshot shortcut");
+    }
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,0 +1,39 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+mod app_state;
+mod browser;
+mod focus;
+mod global_hotkeys;
+mod paths;
+mod screenshots;
+mod tray;
+
+use app_state::AppState;
+use tauri::{Manager};
+
+#[tauri::command]
+fn open_chatgpt(app: tauri::AppHandle) {
+    let cfg = app.state::<AppState>().config.lock().unwrap().clone();
+    browser::open(&app, &cfg);
+}
+
+fn main() {
+    tauri::Builder::default()
+        .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            if let Some(w) = app.get_window("main") {
+                let _ = w.show();
+                let _ = w.set_focus();
+            }
+        }))
+        .setup(|app| {
+            let state = AppState::load(app);
+            app.manage(state);
+            global_hotkeys::register(app);
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![open_chatgpt])
+        .system_tray(tray::create())
+        .on_system_tray_event(tray::handler)
+        .run(tauri::generate_context!())
+        .expect("error running tauri application");
+}

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -1,0 +1,25 @@
+use std::path::PathBuf;
+use tauri::AppHandle;
+
+pub fn app_dir(app: &AppHandle) -> PathBuf {
+    tauri::api::path::app_data_dir(app.config()).expect("app dir")
+}
+
+pub fn config_path(app: &AppHandle) -> PathBuf {
+    app_dir(app).join("config.json")
+}
+
+pub fn snippets_path(app: &AppHandle) -> PathBuf {
+    app_dir(app).join("snippets.json")
+}
+
+pub fn screenshots_dir() -> PathBuf {
+    dirs::home_dir().unwrap().join("Pictures").join("ChatGPT-Shots")
+}
+
+pub fn screenshot_file() -> PathBuf {
+    use chrono::Local;
+    let dir = screenshots_dir();
+    std::fs::create_dir_all(&dir).ok();
+    dir.join(format!("{}.png", Local::now().format("%Y%m%d-%H%M%S")))
+}

--- a/src-tauri/src/screenshots.rs
+++ b/src-tauri/src/screenshots.rs
@@ -1,0 +1,21 @@
+use std::process::Command;
+use tauri::AppHandle;
+
+use crate::{app_state::Config, browser, paths};
+
+pub fn capture(app: &AppHandle, cfg: &Config) {
+    if which::which("scrot").is_err() {
+        tauri::api::dialog::message(Some(&app.get_window("main").unwrap()), "scrot not installed. Install with: sudo apt install scrot");
+        return;
+    }
+    let file = paths::screenshot_file();
+    let path_str = file.to_string_lossy().to_string();
+    let status = Command::new("scrot").args(["-s", &path_str]).status();
+    if status.map(|s| s.success()).unwrap_or(false) {
+        let _ = tauri::api::notification::Notification::new(&app.config().tauri.bundle.identifier)
+            .title("Screenshot saved")
+            .body(&path_str)
+            .show();
+        browser::open(app, cfg);
+    }
+}

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -1,0 +1,32 @@
+use tauri::{CustomMenuItem, SystemTray, SystemTrayEvent, SystemTrayMenu, AppHandle, Manager};
+
+use crate::{app_state::AppState, browser, screenshots};
+
+pub fn create() -> SystemTray {
+    let open = CustomMenuItem::new("open_chatgpt", "Open ChatGPT");
+    let prompt = CustomMenuItem::new("quick_prompt", "Quick Prompt");
+    let shot = CustomMenuItem::new("screenshot", "Screenshot to File");
+    let quit = CustomMenuItem::new("quit", "Quit");
+    let menu = SystemTrayMenu::new()
+        .add_item(open)
+        .add_item(prompt)
+        .add_item(shot)
+        .add_native_item(tauri::SystemTrayMenuItem::Separator)
+        .add_item(quit);
+    SystemTray::new().with_menu(menu)
+}
+
+pub fn handler(app: &AppHandle, event: SystemTrayEvent) {
+    if let SystemTrayEvent::MenuItemClick { id, .. } = event {
+        let cfg = app.state::<AppState>().config.lock().unwrap().clone();
+        match id.as_str() {
+            "open_chatgpt" => browser::open(app, &cfg),
+            "quick_prompt" => {
+                if let Some(w) = app.get_window("main") { let _ = w.show(); let _ = w.set_focus(); }
+            }
+            "screenshot" => screenshots::capture(app, &cfg),
+            "quit" => app.exit(0),
+            _ => {}
+        }
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,0 +1,43 @@
+{
+  "package": {
+    "productName": "ChatGPT Shell",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "bundle": {
+      "identifier": "com.example.chatgptshell",
+      "icon": ["icons/icon.svg"],
+      "resources": ["../src/config.json", "../src/snippets.json", "../src/privacy.md"]
+    },
+    "windows": [
+      {
+        "title": "Quick Prompt",
+        "width": 600,
+        "height": 120,
+        "visible": false,
+        "resizable": false
+      }
+    ],
+    "allowlist": {
+      "all": false,
+      "globalShortcut": {
+        "all": true
+      },
+      "shell": {
+        "open": true
+      },
+      "clipboard": {
+        "writeText": true
+      },
+      "dialog": {
+        "message": true
+      },
+      "notification": {
+        "all": true
+      },
+      "window": {
+        "all": true
+      }
+    }
+  }
+}

--- a/src/config.json
+++ b/src/config.json
@@ -1,0 +1,9 @@
+{
+  "chatUrl": "https://chat.openai.com",
+  "hotkeys": {
+    "openChat": "Ctrl+Space",
+    "quickPrompt": "Ctrl+Shift+P",
+    "screenshot": "Ctrl+Shift+S"
+  },
+  "browserCandidates": ["google-chrome", "chromium", "brave-browser"]
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Quick Prompt</title>
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<input id="prompt" type="text" placeholder="Enter prompt here" autofocus />
+<div id="buttons">
+  <button id="copy">Copy to Clipboard</button>
+  <button id="copyFocus">Copy & Focus ChatGPT</button>
+</div>
+<ul id="snippets"></ul>
+<div id="hotkey-info"></div>
+<script type="module" src="main.ts"></script>
+</body>
+</html>

--- a/src/lib/hotkeys.ts
+++ b/src/lib/hotkeys.ts
@@ -1,0 +1,8 @@
+import type { Config } from './storage';
+
+export function showHotkeys(cfg: Config) {
+  const el = document.getElementById('hotkey-info');
+  if (el) {
+    el.textContent = `Open: ${cfg.hotkeys.openChat} | Prompt: ${cfg.hotkeys.quickPrompt} | Screenshot: ${cfg.hotkeys.screenshot}`;
+  }
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,45 @@
+import { BaseDirectory, readTextFile, writeTextFile } from '@tauri-apps/api/fs';
+import { appDir, resolveResource } from '@tauri-apps/api/path';
+
+export interface Hotkeys {
+  openChat: string;
+  quickPrompt: string;
+  screenshot: string;
+}
+
+export interface Config {
+  chatUrl: string;
+  hotkeys: Hotkeys;
+  browserCandidates: string[];
+}
+
+export interface Snippet {
+  title: string;
+  body: string;
+}
+
+async function ensureFile(name: string) {
+  try {
+    await readTextFile(name, { dir: BaseDirectory.App });
+  } catch (_) {
+    const res = await resolveResource(name);
+    const data = await readTextFile(res);
+    await writeTextFile({ path: name, contents: data, dir: BaseDirectory.App });
+  }
+}
+
+export async function loadConfig(): Promise<Config> {
+  await ensureFile('config.json');
+  const data = await readTextFile('config.json', { dir: BaseDirectory.App });
+  return JSON.parse(data) as Config;
+}
+
+export async function loadSnippets(): Promise<Snippet[]> {
+  await ensureFile('snippets.json');
+  const data = await readTextFile('snippets.json', { dir: BaseDirectory.App });
+  return JSON.parse(data) as Snippet[];
+}
+
+export async function saveSnippets(list: Snippet[]): Promise<void> {
+  await writeTextFile({ path: 'snippets.json', contents: JSON.stringify(list, null, 2), dir: BaseDirectory.App });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,53 @@
+import { writeText } from '@tauri-apps/api/clipboard';
+import { invoke } from '@tauri-apps/api/tauri';
+import Fuse from 'fuse.js';
+import { loadSnippets, loadConfig, Snippet } from './lib/storage';
+import { showHotkeys } from './lib/hotkeys';
+
+let snippets: Snippet[] = [];
+let fuse: Fuse<Snippet>;
+
+const input = document.getElementById('prompt') as HTMLInputElement;
+const list = document.getElementById('snippets') as HTMLUListElement;
+
+function render(items: Snippet[]) {
+  list.innerHTML = '';
+  items.slice(0, 5).forEach(sn => {
+    const li = document.createElement('li');
+    li.textContent = sn.title;
+    li.onclick = async () => {
+      await writeText(sn.body);
+      window.close();
+    };
+    list.appendChild(li);
+  });
+}
+
+async function init() {
+  const cfg = await loadConfig();
+  showHotkeys(cfg);
+  snippets = await loadSnippets();
+  fuse = new Fuse(snippets, { keys: ['title', 'body'] });
+  render(snippets);
+}
+init();
+
+input.addEventListener('input', () => {
+  const term = input.value.trim();
+  if (!term) {
+    render(snippets);
+  } else {
+    render(fuse.search(term).map(r => r.item));
+  }
+});
+
+document.getElementById('copy')!.addEventListener('click', async () => {
+  await writeText(input.value);
+  window.close();
+});
+
+document.getElementById('copyFocus')!.addEventListener('click', async () => {
+  await writeText(input.value);
+  await invoke('open_chatgpt');
+  window.close();
+});

--- a/src/privacy.md
+++ b/src/privacy.md
@@ -1,0 +1,6 @@
+# Privacy & Terms
+
+- The application never reads or stores cookies, tokens, or browsing data.
+- It does not automate, scrape, or interact with ChatGPT's web page. It only launches the official site in your browser.
+- Screenshots and snippets are saved only on your local machine and are never uploaded.
+- You are responsible for complying with OpenAI's Terms of Service when using the ChatGPT website.

--- a/src/snippets.json
+++ b/src/snippets.json
@@ -1,0 +1,5 @@
+[
+  { "title": "Explain concept", "body": "Explain the concept of quantum computing in simple terms." },
+  { "title": "Summarize text", "body": "Summarize the following text in one paragraph:" },
+  { "title": "Generate code", "body": "Write a Python function that computes the Fibonacci sequence." }
+]

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,7 @@
+body { font-family: sans-serif; margin: 10px; }
+#prompt { width: 100%; box-sizing: border-box; padding: 4px; }
+#buttons { margin-top: 8px; }
+#snippets { list-style: none; margin: 8px 0 0 0; padding: 0; max-height: 150px; overflow-y: auto; }
+#snippets li { padding: 2px 4px; cursor: pointer; }
+#snippets li:hover { background: #eee; }
+#hotkey-info { margin-top: 6px; font-size: 0.8em; color: #555; }


### PR DESCRIPTION
## Summary
- implement Tauri-based ChatGPT Shell launcher with tray, hotkeys, screenshots and snippet helper
- add configuration, privacy notice and TypeScript quick prompt window
- replace binary tray icon with SVG to allow review tooling

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@tauri-apps%2fapi)*
- `cd src-tauri && cargo check` *(fails: failed to download from https://index.crates.io/config.json due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f1dfade8c832ba01821c39d2a8a43