### PR TITLE
Configure Tauri build to package static app

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tauri = { version = "1", features = ["system-tray", "global-shortcut", "clipboard-manager", "shell-open", "dialog-all", "notification-all", "window"] }
+tauri = { version = "1", features = [ "global-shortcut-all", "clipboard-write-text", "window-all", "dialog-message", "custom-protocol", "global-shortcut", "clipboard-manager", "shell-open", "notification-all", "window"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 which = "5"
@@ -12,3 +12,7 @@ chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
 dirs = "5"
 tauri-plugin-single-instance = "0.1"
+
+[features]
+default = ["custom-protocol"]
+custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,8 +6,14 @@
   "tauri": {
     "bundle": {
       "identifier": "com.example.chatgptshell",
-      "icon": ["icons/icon.svg"],
-      "resources": ["../src/config.json", "../src/snippets.json", "../src/privacy.md"]
+      "icon": [
+        "icons/icon.svg"
+      ],
+      "resources": [
+        "../src/config.json",
+        "../src/snippets.json",
+        "../src/privacy.md"
+      ]
     },
     "windows": [
       {
@@ -39,5 +45,9 @@
         "all": true
       }
     }
+  },
+  "build": {
+    "devPath": "../src",
+    "distDir": "../src"
   }
 }


### PR DESCRIPTION
## Summary
- Load frontend directly from `src` during development and build
- Enable Tauri custom protocol feature for bundling

## Testing
- `npm run lint` *(fails: No files matching the pattern "." were found)*
- `npm run tauri build` *(fails: failed to download from crates.io: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f4782ae14832b98c32bf5b3b6284b