### PR TITLE
docs: add Debian package build example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,26 @@ npm run dev
 npm run tauri build
 ```
 
+## Create a Debian package
+Build assets and produce an installable `.deb`:
+
+```bash
+# compile TypeScript
+npm run build
+
+# compile the Rust backend
+cargo build --release
+
+# install cargo-deb if needed
+cargo install cargo-deb
+
+# package without rebuilding
+cargo deb --no-build
+
+# install the generated package
+sudo dpkg -i target/debian/chatgpt-shell_*.deb
+```
+
+The `.deb` package will appear under `target/debian`.
+
 See [privacy.md](src/privacy.md) for terms.


### PR DESCRIPTION
## Summary
- document steps for building an installable `.deb` using npm and cargo

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: No files matching the pattern ".")*
- `cargo test` *(fails: failed to download crates, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_689f4782ae14832b98c32bf5b3b6284b