### PR TITLE
Fix build by adding TypeScript config

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "tauri dev",
-    "build": "tsc",
+    "build": "tsc && cp src/index.html src/styles.css dist/",
     "tauri": "tauri",
     "lint": "eslint ."
   },

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -24,7 +24,7 @@ async function ensureFile(name: string) {
   } catch (_) {
     const res = await resolveResource(name);
     const data = await readTextFile(res);
-    await writeTextFile({ path: name, contents: data, dir: BaseDirectory.App });
+    await writeTextFile({ path: name, contents: data }, { dir: BaseDirectory.App });
   }
 }
 
@@ -41,5 +41,5 @@ export async function loadSnippets(): Promise<Snippet[]> {
 }
 
 export async function saveSnippets(list: Snippet[]): Promise<void> {
-  await writeTextFile({ path: 'snippets.json', contents: JSON.stringify(list, null, 2), dir: BaseDirectory.App });
+  await writeTextFile({ path: 'snippets.json', contents: JSON.stringify(list, null, 2) }, { dir: BaseDirectory.App });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- compile TypeScript sources into dist and copy HTML/CSS assets
- correct writeTextFile usage to provide directory in options
- add tsconfig.json for TypeScript compiler

## Testing
- `npm run build`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689f5479dab8832bb216f4268da96861