### PR TITLE
fix: update single instance plugin version

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ which = "5"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
 dirs = "5"
-tauri-plugin-single-instance = "0.1"
+tauri-plugin-single-instance = "2.3.2"
 
 [features]
 default = ["custom-protocol"]


### PR DESCRIPTION
## Summary
- use latest `tauri-plugin-single-instance`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `cargo test --manifest-path src-tauri/Cargo.toml` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `npm run tauri build` *(fails: Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_689ffb48e11c832b97637a263835d19d