### PR TITLE
fix: remove invalid tauri feature

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tauri = { version = "1", features = [ "global-shortcut-all", "clipboard-write-text", "window-all", "dialog-message", "custom-protocol", "global-shortcut", "clipboard-manager", "shell-open", "notification-all", "window"] }
+tauri = { version = "1", features = [ "global-shortcut-all", "clipboard-write-text", "window-all", "dialog-message", "custom-protocol", "global-shortcut", "shell-open", "notification-all", "window"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 which = "5"


### PR DESCRIPTION
## Summary
- drop `clipboard-manager` feature from tauri dependency

## Testing
- `cargo check` *(fails: failed to download index: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_689ffdc0f19c832b9bd8929296975462