### PR TITLE
fix: use valid tauri features

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tauri = { version = "1", features = [ "global-shortcut-all", "clipboard-write-text", "window-all", "dialog-message", "custom-protocol", "global-shortcut", "shell-open", "notification-all", "window"] }
+tauri = { version = "1", features = ["clipboard", "dialog-message", "global-shortcut", "notification", "shell-open", "window", "custom-protocol"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 which = "5"


### PR DESCRIPTION
## Summary
- align tauri dependency features with v1 names

## Testing
- `cargo check` *(fails: Failed to download from https://index.crates.io/config.json, CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a00138b538832baabe79fcf55fc635