### PR TITLE
fix: remove invalid tauri window feature

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tauri = { version = "1", features = [ "global-shortcut-all", "clipboard-write-text", "window-all", "notification-all", "clipboard", "dialog-message", "global-shortcut", "notification", "shell-open", "window", "custom-protocol"] }
+tauri = { version = "1", features = [
+    "global-shortcut-all",
+    "clipboard-write-text",
+    "window-all",
+    "notification-all",
+    "dialog-message",
+    "shell-open",
+    "custom-protocol"
+] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 which = "5"


### PR DESCRIPTION
## Summary
- remove unsupported `window` feature from Tauri dependencies
- streamline Tauri feature list

## Testing
- `npm run tauri build` *(fails: failed to download from crates.io (403))*

------
https://chatgpt.com/codex/tasks/task_e_68a2c0174280832bbd76eda1f997cd36