### PR TITLE
Improve error handling

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -30,9 +30,13 @@ impl AppState {
         if !path.exists() {
             if let Some(res) = app.path_resolver().resolve_resource("config.json") {
                 if let Some(parent) = path.parent() {
-                    std::fs::create_dir_all(parent).ok();
+                    if let Err(e) = std::fs::create_dir_all(parent) {
+                        eprintln!("failed to create config directory: {e}");
+                    }
                 }
-                let _ = std::fs::copy(res, &path);
+                if let Err(e) = std::fs::copy(res, &path) {
+                    eprintln!("failed to copy default config: {e}");
+                }
             }
         }
         let data = match std::fs::read_to_string(&path) {

--- a/src-tauri/src/global_hotkeys.rs
+++ b/src-tauri/src/global_hotkeys.rs
@@ -9,7 +9,9 @@ pub fn register(app: &AppHandle) {
         let cfg = open_app.state::<AppState>().config.lock().unwrap().clone();
         browser::open(&open_app, &cfg);
     }) {
-        tauri::api::dialog::message(Some(&app.get_window("main").unwrap()), "Failed to register open shortcut");
+        if let Some(win) = app.get_window("main") {
+            tauri::api::dialog::message(Some(&win), "Failed to register open shortcut");
+        }
     }
     let prompt_app = app.clone();
     if let Err(_) = app.global_shortcut_manager().register(cfg.hotkeys.quick_prompt.clone(), move || {
@@ -18,13 +20,17 @@ pub fn register(app: &AppHandle) {
             if vis { let _ = w.hide(); } else { let _ = w.show(); let _ = w.set_focus(); }
         }
     }) {
-        tauri::api::dialog::message(Some(&app.get_window("main").unwrap()), "Failed to register prompt shortcut");
+        if let Some(win) = app.get_window("main") {
+            tauri::api::dialog::message(Some(&win), "Failed to register prompt shortcut");
+        }
     }
     let shot_app = app.clone();
     if let Err(_) = app.global_shortcut_manager().register(cfg.hotkeys.screenshot.clone(), move || {
         let cfg = shot_app.state::<AppState>().config.lock().unwrap().clone();
         screenshots::capture(&shot_app, &cfg);
     }) {
-        tauri::api::dialog::message(Some(&app.get_window("main").unwrap()), "Failed to register screenshot shortcut");
+        if let Some(win) = app.get_window("main") {
+            tauri::api::dialog::message(Some(&win), "Failed to register screenshot shortcut");
+        }
     }
 }

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -2,7 +2,10 @@ use std::path::PathBuf;
 use tauri::AppHandle;
 
 pub fn app_dir(app: &AppHandle) -> PathBuf {
-    tauri::api::path::app_data_dir(app.config()).expect("app dir")
+    tauri::api::path::app_data_dir(app.config()).unwrap_or_else(|| {
+        eprintln!("failed to get app data dir, using current dir");
+        std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    })
 }
 
 pub fn config_path(app: &AppHandle) -> PathBuf {
@@ -14,12 +17,14 @@ pub fn snippets_path(app: &AppHandle) -> PathBuf {
 }
 
 pub fn screenshots_dir() -> PathBuf {
-    dirs::home_dir().unwrap().join("Pictures").join("ChatGPT-Shots")
+    dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")).join("Pictures").join("ChatGPT-Shots")
 }
 
 pub fn screenshot_file() -> PathBuf {
     use chrono::Local;
     let dir = screenshots_dir();
-    std::fs::create_dir_all(&dir).ok();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        eprintln!("failed to create screenshot directory: {e}");
+    }
     dir.join(format!("{}.png", Local::now().format("%Y%m%d-%H%M%S")))
 }

--- a/src-tauri/src/screenshots.rs
+++ b/src-tauri/src/screenshots.rs
@@ -5,17 +5,27 @@ use crate::{app_state::Config, browser, paths};
 
 pub fn capture(app: &AppHandle, cfg: &Config) {
     if which::which("scrot").is_err() {
-        tauri::api::dialog::message(Some(&app.get_window("main").unwrap()), "scrot not installed. Install with: sudo apt install scrot");
+        let win = app.get_window("main");
+        tauri::api::dialog::message(win.as_ref(), "scrot not installed. Install with: sudo apt install scrot");
         return;
     }
     let file = paths::screenshot_file();
     let path_str = file.to_string_lossy().to_string();
-    let status = Command::new("scrot").args(["-s", &path_str]).status();
-    if status.map(|s| s.success()).unwrap_or(false) {
-        let _ = tauri::api::notification::Notification::new(&app.config().tauri.bundle.identifier)
-            .title("Screenshot saved")
-            .body(&path_str)
-            .show();
-        browser::open(app, cfg);
+    match Command::new("scrot").args(["-s", &path_str]).status() {
+        Ok(status) if status.success() => {
+            if let Err(e) = tauri::api::notification::Notification::new(&app.config().tauri.bundle.identifier)
+                .title("Screenshot saved")
+                .body(&path_str)
+                .show()
+            {
+                eprintln!("failed to show notification: {e}");
+            }
+            browser::open(app, cfg);
+        }
+        _ => {
+            eprintln!("failed to capture screenshot");
+            let win = app.get_window("main");
+            tauri::api::dialog::message(win.as_ref(), "Failed to capture screenshot");
+        }
     }
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -22,9 +22,14 @@ async function ensureFile(name: string) {
   try {
     await readTextFile(name, { dir: BaseDirectory.App });
   } catch (_) {
-    const res = await resolveResource(name);
-    const data = await readTextFile(res);
-    await writeTextFile({ path: name, contents: data }, { dir: BaseDirectory.App });
+    try {
+      const res = await resolveResource(name);
+      const data = await readTextFile(res);
+      await writeTextFile({ path: name, contents: data }, { dir: BaseDirectory.App });
+    } catch (err) {
+      console.error(`Failed to initialize ${name}`, err);
+      throw err;
+    }
   }
 }
 
@@ -51,5 +56,13 @@ export async function loadSnippets(): Promise<Snippet[]> {
 }
 
 export async function saveSnippets(list: Snippet[]): Promise<void> {
-  await writeTextFile({ path: 'snippets.json', contents: JSON.stringify(list, null, 2) }, { dir: BaseDirectory.App });
+  try {
+    await writeTextFile(
+      { path: 'snippets.json', contents: JSON.stringify(list, null, 2) },
+      { dir: BaseDirectory.App }
+    );
+  } catch (err) {
+    console.error('Failed to save snippets', err);
+    throw err;
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,12 +47,22 @@ input.addEventListener('input', () => {
 });
 
 document.getElementById('copy')!.addEventListener('click', async () => {
-  await writeText(input.value);
-  window.close();
+  try {
+    await writeText(input.value);
+    window.close();
+  } catch (err) {
+    console.error('Failed to copy text', err);
+    alert('Unable to copy to clipboard');
+  }
 });
 
 document.getElementById('copyFocus')!.addEventListener('click', async () => {
-  await writeText(input.value);
-  await invoke('open_chatgpt');
-  window.close();
+  try {
+    await writeText(input.value);
+    await invoke('open_chatgpt');
+    window.close();
+  } catch (err) {
+    console.error('Failed to copy or open ChatGPT', err);
+    alert('Unable to copy text or open ChatGPT');
+  }
 });


### PR DESCRIPTION
## Summary
- add try/catch around clipboard and ChatGPT invocation actions
- handle file init and save errors when reading/writing snippets
- improve Tauri modules with basic error reporting for browser launch, shortcuts, screenshots, paths, and config

## Testing
- `npm run build`
- `npm run lint` (fails: ESLint couldn't find a configuration file)
- `cargo check` (fails: Failure when receiving data from the peer)

------
https://chatgpt.com/codex/tasks/task_e_68a2c1cd084c832bb7bb794ab41cd3fb