### PR TITLE
fix: use tauri v1 single instance plugin

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,8 @@ which = "5"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
 dirs = "5"
-tauri-plugin-single-instance = "2.3.2"
+# Use the Tauri 1 compatible version of the single instance plugin.
+tauri-plugin-single-instance = "1"
 
 [features]
 default = ["custom-protocol"]


### PR DESCRIPTION
## Summary
- Use tauri-plugin-single-instance v1 to match Tauri v1 dependencies

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run tauri build` *(fails: failed to download from crates.io, CONNECT tunnel 403)*


------
https://chatgpt.com/codex/tasks/task_e_68a2c35f3d48832b9e83e17dc7dd30db