### PR TITLE
Fix build by updating single instance plugin version

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,8 +19,8 @@ which = "5"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
 dirs = "5"
-# Use the Tauri 1 compatible version of the single instance plugin.
-tauri-plugin-single-instance = "1"
+# Use the latest Tauri-compatible version of the single instance plugin.
+tauri-plugin-single-instance = "2"
 
 [features]
 default = ["custom-protocol"]


### PR DESCRIPTION
## Summary
- update tauri single instance plugin to latest v2

## Testing
- `npm run tauri build` *(fails: failed to download from https://index.crates.io/config.json, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ce075710832b9c4706fb66e19648