### PR TITLE
Remove extraneous runtime dependencies

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,10 +15,7 @@ tauri = { version = "1", features = [
 ] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-which = "5"
-chrono = { version = "0.4", features = ["serde"] }
 thiserror = "1"
-dirs = "5"
 # Use the latest Tauri-compatible version of the single instance plugin.
 tauri-plugin-single-instance = "2"
 

--- a/src-tauri/src/browser.rs
+++ b/src-tauri/src/browser.rs
@@ -1,4 +1,4 @@
-use std::process::Command;
+use std::{env, process::Command};
 use tauri::AppHandle;
 
 use crate::{app_state::Config, focus};
@@ -8,7 +8,7 @@ pub fn open(app: &AppHandle, cfg: &Config) {
         return;
     }
     for b in &cfg.browser_candidates {
-        if which::which(b).is_ok() {
+        if command_exists(b) {
             if let Err(e) = Command::new(b)
                 .args([format!("--app={}", cfg.chat_url), String::from("--new-window")])
                 .spawn()
@@ -38,4 +38,10 @@ pub fn open(app: &AppHandle, cfg: &Config) {
             }
         }
     }
+}
+
+fn command_exists(cmd: &str) -> bool {
+    env::var_os("PATH").map_or(false, |paths| {
+        env::split_paths(&paths).any(|p| p.join(cmd).exists())
+    })
 }

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -17,14 +17,22 @@ pub fn snippets_path(app: &AppHandle) -> PathBuf {
 }
 
 pub fn screenshots_dir() -> PathBuf {
-    dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")).join("Pictures").join("ChatGPT-Shots")
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("Pictures")
+        .join("ChatGPT-Shots")
 }
 
 pub fn screenshot_file() -> PathBuf {
-    use chrono::Local;
+    use std::time::{SystemTime, UNIX_EPOCH};
     let dir = screenshots_dir();
     if let Err(e) = std::fs::create_dir_all(&dir) {
         eprintln!("failed to create screenshot directory: {e}");
     }
-    dir.join(format!("{}.png", Local::now().format("%Y%m%d-%H%M%S")))
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    dir.join(format!("{ts}.png"))
 }

--- a/src-tauri/src/screenshots.rs
+++ b/src-tauri/src/screenshots.rs
@@ -1,10 +1,10 @@
-use std::process::Command;
+use std::{env, process::Command};
 use tauri::AppHandle;
 
 use crate::{app_state::Config, browser, paths};
 
 pub fn capture(app: &AppHandle, cfg: &Config) {
-    if which::which("scrot").is_err() {
+    if !command_exists("scrot") {
         let win = app.get_window("main");
         tauri::api::dialog::message(win.as_ref(), "scrot not installed. Install with: sudo apt install scrot");
         return;
@@ -28,4 +28,10 @@ pub fn capture(app: &AppHandle, cfg: &Config) {
             tauri::api::dialog::message(win.as_ref(), "Failed to capture screenshot");
         }
     }
+}
+
+fn command_exists(cmd: &str) -> bool {
+    env::var_os("PATH").map_or(false, |paths| {
+        env::split_paths(&paths).any(|p| p.join(cmd).exists())
+    })
 }


### PR DESCRIPTION
## Summary
- drop chrono, dirs, and which crates by using standard library helpers
- create timestamp-based screenshot naming without chrono
- check browser and screenshot tools with custom PATH lookup

## Testing
- `npm run build`
- `npm run tauri build` *(fails: failed to download from `https://index.crates.io/config.json` (CONNECT tunnel failed, response 403))*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68bd59427488832bb1014b6aa47a505a